### PR TITLE
Fixes BraveH/gear-switch-alert#11 Longrange casting 

### DIFF
--- a/src/main/java/com/gearswitch/AttackStyle.java
+++ b/src/main/java/com/gearswitch/AttackStyle.java
@@ -13,6 +13,7 @@ enum AttackStyle
     LONGRANGE("Longrange", Skill.RANGED, Skill.DEFENCE),
     CASTING("Casting", Skill.MAGIC),
     DEFENSIVE_CASTING("Defensive Casting", Skill.MAGIC, Skill.DEFENCE),
+    LONGRANGE_CASTING("Longrange Casting", Skill.MAGIC, Skill.DEFENCE),
     OTHER("Other");
 
     @Getter

--- a/src/main/java/com/gearswitch/GearSwitchAlertPlugin.java
+++ b/src/main/java/com/gearswitch/GearSwitchAlertPlugin.java
@@ -214,6 +214,8 @@ public class GearSwitchAlertPlugin extends Plugin
 				newAttackStyle = OTHER;
 			} else if ((newAttackStyle == CASTING) && (castingMode == 1)) {
 				newAttackStyle = DEFENSIVE_CASTING;
+			} else if ((newAttackStyle == DEFENSIVE) && (attackStyles[0] == CASTING)) {
+				newAttackStyle = LONGRANGE_CASTING;
 			}
 		}
 
@@ -231,6 +233,7 @@ public class GearSwitchAlertPlugin extends Plugin
 				break;
 			case CASTING:
 			case DEFENSIVE_CASTING:
+			case LONGRANGE_CASTING:
 				newAttackType = AttackType.MAGIC;
 				break;
 		}


### PR DESCRIPTION
Fixes BraveH/gear-switch-alert#11 Longrange casting was showing as melee for Toxic Trident (Tested) and other powered staffs (didn't have access to shadow so not tested).