### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dynamic Inventory Tags (v1.1.2)
 
-[![Active Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/dynamic-inventory-tags)](https://runelite.net/plugin-hub/show/dynamic-inventory-tags)
-[![Plugin Rank](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/dynamic-inventory-tags)](https://runelite.net/plugin-hub/show/dynamic-inventory-tags)
+[![Active Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/dynamic-inventory-tags)](https://runelite.net/plugin-hub/show/dynamic-inventory-tags)
+[![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/dynamic-inventory-tags)](https://runelite.net/plugin-hub/show/dynamic-inventory-tags)
 
 A plugin to tag gear items that are missing from your current switch. Depending on the weapon type equipped, melee/range/magic gear gets highlighted accordingly if they aren't equipped.
 To set if an item is meant to be defined as Melee gear, Range gear, or Magic gear... shift + right click the item and set it manually.


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/gear-switch-alert) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: