### PR TITLE
Correcting LONGRANGE Casting Conditions

### DIFF
--- a/src/main/java/com/gearswitch/GearSwitchAlertPlugin.java
+++ b/src/main/java/com/gearswitch/GearSwitchAlertPlugin.java
@@ -216,7 +216,7 @@ public class GearSwitchAlertPlugin extends Plugin
 				newAttackStyle = OTHER;
 			} else if ((newAttackStyle == DEFENSIVE) && (attackStyles[0] == CASTING)) {
 				newAttackStyle = DEFENSIVE_CASTING;
-			} else if ((newAttackStyle == DEFENSIVE) && (attackStyles[0] == CASTING)) {
+			} else if ((newAttackStyle == LONGRANGE) && (attackStyles[0] == CASTING)) {
 				newAttackStyle = LONGRANGE_CASTING;
 			}
 		}


### PR DESCRIPTION
Fixing issue where conditional statement was not catching longrange casting. There was a repeated else if condition for defensive casting instead of being for longrange casting. 