### PR TITLE
Add special attack gear tag support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/src/main/java/com/gearswitch/GearSwitchAlertConfig.java
+++ b/src/main/java/com/gearswitch/GearSwitchAlertConfig.java
@@ -52,6 +52,18 @@ public interface GearSwitchAlertConfig extends Config
 	{
 		return Color.BLUE;
 	}
+	@Alpha
+	@ConfigItem(
+			keyName = "defaultColourSpecial",
+			name = "Special Tag",
+			description = "Default special tag colour",
+			position = 3,
+			section = defaultColourSection
+	)
+	default Color defaultColourSpecial()
+	{
+		return new Color(0xCA00FF);
+	}
 	@ConfigSection(
 			name = "Tag Display Mode",
 			description = "How tags are displayed in the inventory",

--- a/src/main/java/com/gearswitch/GearSwitchAlertPlugin.java
+++ b/src/main/java/com/gearswitch/GearSwitchAlertPlugin.java
@@ -11,7 +11,9 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.Menu;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.InterfaceID;
@@ -89,6 +91,10 @@ public class GearSwitchAlertPlugin extends Plugin
 
 	@Getter
     private AttackType attackType;
+	@Getter
+	private boolean equippedWeaponSpecial;
+	@Getter
+	private boolean pendingTwoHandedEquip;
 	private boolean isCurrentTwoHanded;
 	private static final String TAG_KEY_PREFIX = "gear_tag_";
 	private static final String PROFILES_PREFIX = "gear_profiles";
@@ -151,6 +157,7 @@ public class GearSwitchAlertPlugin extends Plugin
 			return;
 		}
 
+		pendingTwoHandedEquip = false;
 		UpdateEquippedWeaponInfo(true);
 	}
 
@@ -251,7 +258,17 @@ public class GearSwitchAlertPlugin extends Plugin
 			}
 		}
 
+		updateEquippedWeaponSpecial();
 		overlay.resetDelayTimer();
+	}
+
+	void updateEquippedWeaponSpecial() {
+		ItemContainer equipmentContainer = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (equipmentContainer == null) { equippedWeaponSpecial = false; return; }
+		Item weapon = equipmentContainer.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx());
+		if (weapon == null) { equippedWeaponSpecial = false; return; }
+		GearTagSettings tag = getTag(weapon.getId());
+		equippedWeaponSpecial = tag != null && tag.isSpecialGear;
 	}
 
 	GearTagSettings getTag(int itemId) {
@@ -336,6 +353,7 @@ public class GearSwitchAlertPlugin extends Plugin
 		String profilePrefix = profileUUID.equals("0") ? "" : profileUUID + "_";
 		configManager.setConfiguration(GearSwitchAlertConfig.GROUP, TAG_KEY_PREFIX + profilePrefix + itemId, json);
 		overlay.invalidateCache();
+		clientThread.invokeLater(this::updateEquippedWeaponSpecial);
 		ProfilePanel tile = panel.getEnabledProfileTile();
 		if(tile != null)
 			clientThread.invokeLater(tile::rebuild);
@@ -383,15 +401,17 @@ public class GearSwitchAlertPlugin extends Plugin
 							.setOption("Gear Switch Alert Tagging")
 							.createSubMenu();
 
-					boolean isMeleeEnabled, isRangeEnabled, isMagicEnabled;
+					boolean isMeleeEnabled, isRangeEnabled, isMagicEnabled, isSpecialEnabled;
 					if (gearTagSettings != null) {
 						isMeleeEnabled = gearTagSettings.isMeleeGear;
 						isRangeEnabled = gearTagSettings.isRangeGear;
 						isMagicEnabled = gearTagSettings.isMagicGear;
+						isSpecialEnabled = gearTagSettings.isSpecialGear;
 					} else {
 						isMagicEnabled = false;
 						isMeleeEnabled = false;
 						isRangeEnabled = false;
+						isSpecialEnabled = false;
 					}
 					int finalItemId = itemId;
 
@@ -399,30 +419,36 @@ public class GearSwitchAlertPlugin extends Plugin
 							.setOption(ColorUtil.prependColorTag(isMeleeEnabled ? "Unset Melee Gear" : "Set Melee Gear", config.defaultColourMelee()))
 							.setType(MenuAction.RUNELITE)
 							.onClick(e ->
-									toggleGearTag(gearTagSettings, finalItemId, true, false, false));
+									toggleGearTag(gearTagSettings, finalItemId, true, false, false, false));
 
 					parent.createMenuEntry(0)
 							.setOption(ColorUtil.prependColorTag(isRangeEnabled ? "Unset Range Gear" : "Set Range Gear", config.defaultColourRanged()))
 							.setType(MenuAction.RUNELITE)
 							.onClick(e ->
-									toggleGearTag(gearTagSettings, finalItemId, false, true, false));
+									toggleGearTag(gearTagSettings, finalItemId, false, true, false, false));
 
 					parent.createMenuEntry(0)
 							.setOption(ColorUtil.prependColorTag(isMagicEnabled ? "Unset Magic Gear" : "Set Magic Gear", config.defaultColourMagic()))
 							.setType(MenuAction.RUNELITE)
 							.onClick(e ->
-									toggleGearTag(gearTagSettings, finalItemId, false, false, true));
+									toggleGearTag(gearTagSettings, finalItemId, false, false, true, false));
+
+					parent.createMenuEntry(0)
+							.setOption(ColorUtil.prependColorTag(isSpecialEnabled ? "Unset Special Gear" : "Set Special Gear", config.defaultColourSpecial()))
+							.setType(MenuAction.RUNELITE)
+							.onClick(e ->
+									toggleGearTag(gearTagSettings, finalItemId, false, false, false, true));
 
 				}
 			}
 		}
 	}
 
-	public void toggleGearTag(GearTagSettingsWithItemID tag, boolean toggleMelee, boolean toggleRanged, boolean toggleMagic) {
-		toggleGearTag(tag.origTag, tag.itemID, toggleMelee, toggleRanged, toggleMagic);
+	public void toggleGearTag(GearTagSettingsWithItemID tag, boolean toggleMelee, boolean toggleRanged, boolean toggleMagic, boolean toggleSpecial) {
+		toggleGearTag(tag.origTag, tag.itemID, toggleMelee, toggleRanged, toggleMagic, toggleSpecial);
 	}
 
-	public void toggleGearTag(GearTagSettings tag, int itemId, boolean toggleMelee, boolean toggleRanged, boolean toggleMagic) {
+	public void toggleGearTag(GearTagSettings tag, int itemId, boolean toggleMelee, boolean toggleRanged, boolean toggleMagic, boolean toggleSpecial) {
 		GearTagSettings newGearTagSettings = tag;
 		if (newGearTagSettings == null)
 			newGearTagSettings = new GearTagSettings();
@@ -430,6 +456,7 @@ public class GearSwitchAlertPlugin extends Plugin
 		newGearTagSettings.isMeleeGear = toggleMelee != newGearTagSettings.isMeleeGear;
 		newGearTagSettings.isRangeGear = toggleRanged != newGearTagSettings.isRangeGear;
 		newGearTagSettings.isMagicGear = toggleMagic != newGearTagSettings.isMagicGear;
+		newGearTagSettings.isSpecialGear = toggleSpecial != newGearTagSettings.isSpecialGear;
 		setTag(itemId, newGearTagSettings);
 	}
 
@@ -649,6 +676,28 @@ public class GearSwitchAlertPlugin extends Plugin
 		} else {
 			SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(parent, "Profile Not Found!", null, JOptionPane.ERROR_MESSAGE));
 		}
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event) {
+		String option = event.getMenuOption();
+		if (!"Wear".equals(option) && !"Wield".equals(option) && !"Equip".equals(option)) {
+			return;
+		}
+		Widget widget = event.getWidget();
+		if (widget == null) return;
+		int itemId = widget.getItemId();
+		if (itemId == -1) return;
+		ItemStats stats = getItemStats(itemId);
+		if (stats == null || stats.getEquipment() == null) return;
+		if (stats.getEquipment().isTwoHanded()) {
+			pendingTwoHandedEquip = true;
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event) {
+		pendingTwoHandedEquip = false;
 	}
 
 	@Subscribe

--- a/src/main/java/com/gearswitch/GearTagSettings.java
+++ b/src/main/java/com/gearswitch/GearTagSettings.java
@@ -8,6 +8,7 @@ class GearTagSettings
     boolean isMeleeGear;
     boolean isRangeGear;
     boolean isMagicGear;
+    boolean isSpecialGear;
 
     public int getWeight() {
         return (isMeleeGear ? 100 : 0) + (isRangeGear ? 10 : 0) + (isMagicGear ? 1 : 0);

--- a/src/main/java/com/gearswitch/GearsInventoryTagsOverlay.java
+++ b/src/main/java/com/gearswitch/GearsInventoryTagsOverlay.java
@@ -27,9 +27,11 @@ package com.gearswitch;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemStats;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
@@ -86,29 +88,42 @@ class GearsInventoryTagsOverlay extends WidgetItemOverlay
             return;
         }
 
-        AttackType attackType = plugin.getAttackType();
-        Color color = null;
-        switch (attackType) {
-            case RANGE:
-                if(!gearTagSettings.isRangeGear)
-                    return;
-
-                color = config.defaultColourRanged();
-                break;
-            case MAGIC:
-                if(!gearTagSettings.isMagicGear)
-                    return;
-
-                color = config.defaultColourMagic();
-                break;
-            case MELEE:
-                if(!gearTagSettings.isMeleeGear)
-                    return;
-
-                color = config.defaultColourMelee();
-                break;
-            case OTHER:
+        if (plugin.isPendingTwoHandedEquip()) {
+            ItemStats shieldCheck = itemManager.getItemStats(itemId);
+            if (shieldCheck != null && shieldCheck.getEquipment() != null
+                    && shieldCheck.getEquipment().getSlot() == EquipmentInventorySlot.SHIELD.getSlotIdx()) {
                 return;
+            }
+        }
+
+        Color color = null;
+        if (plugin.isEquippedWeaponSpecial()) {
+            if (!gearTagSettings.isSpecialGear)
+                return;
+            if (isWeapon(itemId))
+                return;
+            color = config.defaultColourSpecial();
+        } else {
+            AttackType attackType = plugin.getAttackType();
+            switch (attackType) {
+                case RANGE:
+                    if (!gearTagSettings.isRangeGear)
+                        return;
+                    color = config.defaultColourRanged();
+                    break;
+                case MAGIC:
+                    if (!gearTagSettings.isMagicGear)
+                        return;
+                    color = config.defaultColourMagic();
+                    break;
+                case MELEE:
+                    if (!gearTagSettings.isMeleeGear)
+                        return;
+                    color = config.defaultColourMelee();
+                    break;
+                case OTHER:
+                    return;
+            }
         }
 
         Rectangle bounds = widgetItem.getCanvasBounds();
@@ -168,6 +183,12 @@ class GearsInventoryTagsOverlay extends WidgetItemOverlay
             fillCache.put(key, image);
         }
         return image;
+    }
+
+    private boolean isWeapon(int itemId) {
+        ItemStats stats = itemManager.getItemStats(itemId);
+        if (stats == null || stats.getEquipment() == null) return false;
+        return stats.getEquipment().getSlot() == EquipmentInventorySlot.WEAPON.getSlotIdx();
     }
 
     void invalidateCache()

--- a/src/main/java/com/gearswitch/ProfilePanel.java
+++ b/src/main/java/com/gearswitch/ProfilePanel.java
@@ -43,7 +43,7 @@ class ProfilePanel extends JPanel {
     static final ImageIcon EXPANDED_ICON_HOVER;
     static final ImageIcon PLUS_ICON;
     static final ImageIcon PLUS_ICON_HOVER;
-    private static final int PRAYER_SIZE = 12;
+    private static final int PRAYER_SIZE = 9;
 
     final JPanel rowContainer = new JPanel();
     final JPanel rightPanel = new JPanel();
@@ -261,7 +261,7 @@ class ProfilePanel extends JPanel {
             imageLabel2.setHorizontalAlignment(SwingConstants.CENTER);
 
             AsyncBufferedImage prayerImg = new AsyncBufferedImage(clientThread, width, PRAYER_SIZE, TYPE_INT_ARGB);
-            prayerImg = applyPrayerToImage(prayerImg, tag.isMeleeGear, tag.isRangeGear, tag.isMagicGear);
+            prayerImg = applyPrayerToImage(prayerImg, tag.isMeleeGear, tag.isRangeGear, tag.isMagicGear, tag.isSpecialGear);
             prayerImg.addTo(imageLabel2);
 
             imageLabel2.setBounds( 0, height, width, PRAYER_SIZE );
@@ -276,15 +276,19 @@ class ProfilePanel extends JPanel {
 
             final JMenuItem meleeToggle = new JMenuItem(tag.isMeleeGear ? "Unset Melee Gear" : "Set Melee Gear");
             meleeToggle.addActionListener(e ->
-                    plugin.toggleGearTag(item, true, false, false));
+                    plugin.toggleGearTag(item, true, false, false, false));
 
             final JMenuItem rangeToggle = new JMenuItem(tag.isRangeGear ? "Unset Range Gear" : "Set Range Gear");
             rangeToggle.addActionListener(e ->
-                    plugin.toggleGearTag(item, false, true, false));
+                    plugin.toggleGearTag(item, false, true, false, false));
 
             final JMenuItem magicToggle = new JMenuItem(tag.isMagicGear ? "Unset Magic Gear" : "Set Magic Gear");
             magicToggle.addActionListener(e ->
-                    plugin.toggleGearTag(item, false, false, true));
+                    plugin.toggleGearTag(item, false, false, true, false));
+
+            final JMenuItem specialToggle = new JMenuItem(tag.isSpecialGear ? "Unset Special Gear" : "Set Special Gear");
+            specialToggle.addActionListener(e ->
+                    plugin.toggleGearTag(item, false, false, false, true));
 
             final JMenuItem removeTag = new JMenuItem("Remove Tag");
             removeTag.addActionListener(e ->
@@ -293,10 +297,11 @@ class ProfilePanel extends JPanel {
             popupMenu.add(meleeToggle);
             popupMenu.add(rangeToggle);
             popupMenu.add(magicToggle);
+            popupMenu.add(specialToggle);
             popupMenu.add(removeTag);
 
             String enabledTagsText;
-            if(!tag.isMeleeGear && !tag.isRangeGear && !tag.isMagicGear) {
+            if(!tag.isMeleeGear && !tag.isRangeGear && !tag.isMagicGear && !tag.isSpecialGear) {
                 enabledTagsText = "No Tags Set";
             } else {
                 StringBuilder str = new StringBuilder();
@@ -307,6 +312,8 @@ class ProfilePanel extends JPanel {
                     str.append("Ranged").append(delimiter);
                 if(tag.isMagicGear)
                     str.append("Magic").append(delimiter);
+                if(tag.isSpecialGear)
+                    str.append("Special").append(delimiter);
 
                 String list = str.toString();
                 enabledTagsText = list.substring(
@@ -365,16 +372,17 @@ class ProfilePanel extends JPanel {
         tagsContainer.revalidate();
     }
 
-    public AsyncBufferedImage applyPrayerToImage(AsyncBufferedImage img, boolean melee, boolean range, boolean magic) {
+    public AsyncBufferedImage applyPrayerToImage(AsyncBufferedImage img, boolean melee, boolean range, boolean magic, boolean special) {
         Graphics g = img.getGraphics();
-        int imgWidth = img.getWidth();
 
         BufferedImage meleeSprite = plugin.getSprite(Prayer.PROTECT_FROM_MELEE);
         BufferedImage rangeSprite = plugin.getSprite(Prayer.PROTECT_FROM_MISSILES);
         BufferedImage magicSprite = plugin.getSprite(Prayer.PROTECT_FROM_MAGIC);
-        g.drawImage(melee ? getFillImage(panel.config.defaultColourMelee(), meleeSprite, 0) : getFillImage(ColorUtil.colorWithAlpha(Color.GRAY, 30), meleeSprite, 4), 0, 0, PRAYER_SIZE, PRAYER_SIZE, null);
-        g.drawImage(range ? getFillImage(panel.config.defaultColourRanged(), rangeSprite, 1) : getFillImage(ColorUtil.colorWithAlpha(Color.GRAY, 30), rangeSprite, 5), (imgWidth/2) - (PRAYER_SIZE/2), 0, PRAYER_SIZE, PRAYER_SIZE, null);
-        g.drawImage(magic ? getFillImage(panel.config.defaultColourMagic(), magicSprite, 2) : getFillImage(ColorUtil.colorWithAlpha(Color.GRAY, 30), magicSprite, 6), imgWidth - PRAYER_SIZE, 0, PRAYER_SIZE, PRAYER_SIZE, null);
+        Color gray = ColorUtil.colorWithAlpha(Color.GRAY, 30);
+        g.drawImage(melee  ? getFillImage(panel.config.defaultColourMelee(),    meleeSprite, 0) : getFillImage(gray, meleeSprite, 4), PRAYER_SIZE * 0, 0, PRAYER_SIZE, PRAYER_SIZE, null);
+        g.drawImage(range  ? getFillImage(panel.config.defaultColourRanged(),   rangeSprite, 1) : getFillImage(gray, rangeSprite, 5), PRAYER_SIZE * 1, 0, PRAYER_SIZE, PRAYER_SIZE, null);
+        g.drawImage(magic  ? getFillImage(panel.config.defaultColourMagic(),    magicSprite, 2) : getFillImage(gray, magicSprite, 6), PRAYER_SIZE * 2, 0, PRAYER_SIZE, PRAYER_SIZE, null);
+        g.drawImage(special ? getFillImage(panel.config.defaultColourSpecial(), meleeSprite, 3) : getFillImage(gray, meleeSprite, 7), PRAYER_SIZE * 3, 0, PRAYER_SIZE, PRAYER_SIZE, null);
 
         return img;
     }


### PR DESCRIPTION
Adds support for a fourth gear tag for special attack switches.

This adds:

* A new Special Attack gear tag with configurable default colour
* Set/Unset Special Attack Gear options in the item menu
* Special Attack icon support in the profile panel
* Special-mode highlighting when the equipped weapon is tagged as Special Attack
* Existing melee, ranged, and magic tag behaviour should remain unchanged

I tested this locally in RuneLite with multiple special attack weapons and normal melee/ranged/magic gear switching.
