### PR TITLE
Update runelite-plugin.properties

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -4,3 +4,4 @@ support=https://github.com/BraveH/gear-switch-alert
 description=Sets tags on gear items based on the weapon equipped. Tags gear items that are missing from your current switch.
 tags=gear,switch,missing,tags,inventory
 plugins=com.gearswitch.GearSwitchAlertPlugin
+build=standard


### PR DESCRIPTION
Plugin Hub now requires the plugin properties file to specify a build type using either build=standard or build=gradle. Since this plugin does not appear to need a custom Gradle build setup, build=standard should be the correct option.

This should allow the Plugin Hub PR to pass its packaging checks once the commit reference is updated.